### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 **Prerequisites Installation**
 
-Python 3.7 - https://www.python.org/downloads/release/python-370/
+Python 3.7.1 - https://www.python.org/downloads/release/python-371/
 
 Numpy 1.21.5 - https://pypi.org/project/numpy/1.21.5/
 


### PR DESCRIPTION
Trying to install pandas 1.3.5 will throw errors on environments with Python 3.7 installed, instead Python 3.7.1 should be used.